### PR TITLE
feat!: more useful decorator for transforms

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "DEV"

--- a/.github/test-constraints.txt
+++ b/.github/test-constraints.txt
@@ -1,0 +1,2 @@
+--prefer-binary
+--only-binary numpy,scipy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+name: Release
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    name: Publish on PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - run: pipx run build
+      - uses: pypa/gh-action-pypi-publish@v1.8.6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+name: Test
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  style:
+    name: Style
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: pipx run flake8 fftl
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - run: pip install -c .github/test-constraints.txt '.[test]'
+    - run: pytest
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: pipx run build
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: pipx run --spec '.[docs]' sphinx-build -W -b html docs _build/html

--- a/fftl/scipy.py
+++ b/fftl/scipy.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 
 import numpy as np
 from scipy.special import gamma, loggamma, poch, beta
-from . import fftl
+from . import fftl, transform
 
 SRPI = np.pi**0.5
 
@@ -102,12 +102,13 @@ class HankelTransform:
     >>> res = k*q**(-3-p)*gamma(3+p)*hyp2f1((3+p)/2, (4+p)/2, 2, -(k/q)**2)/2
     >>>
     >>> import matplotlib.pyplot as plt
-    >>> plt.plot(k, ak, '-k', label='numerical')
-    >>> plt.plot(k, res, ':r', label='analytical')
-    >>> plt.xscale('log')
-    >>> plt.yscale('symlog', linthresh=1e0, subs=[2, 3, 4, 5, 6, 7, 8, 9])
-    >>> plt.ylim(-5e-1, 1e2)
-    >>> plt.legend()
+    >>> plt.plot(k, ak, '-k', label='numerical')            # doctest: +SKIP
+    >>> plt.plot(k, res, ':r', label='analytical')          # doctest: +SKIP
+    >>> plt.xscale('log')                                   # doctest: +SKIP
+    >>> plt.yscale('symlog', linthresh=1e0,
+    ...            subs=[2, 3, 4, 5, 6, 7, 8, 9])           # doctest: +SKIP
+    >>> plt.ylim(-5e-1, 1e2)                                # doctest: +SKIP
+    >>> plt.legend()                                        # doctest: +SKIP
     >>> plt.show()
 
     '''
@@ -117,7 +118,7 @@ class HankelTransform:
     def __call__(self, x):
         return 2**x*cpoch((1+self.mu-x)/2, x)
 
-    @fftl.wrap
+    @transform(fftl)
     def fftl(self, r, ar, **kwargs):
         return fftl(self, r, ar*r, **kwargs)
 
@@ -152,9 +153,9 @@ class LaplaceTransform:
     >>> res = gamma(p+1)/(q + k)**(p+1)
     >>>
     >>> import matplotlib.pyplot as plt
-    >>> plt.loglog(k, ak, '-k', label='numerical')
-    >>> plt.loglog(k, res, ':r', label='analytical')
-    >>> plt.legend()
+    >>> plt.loglog(k, ak, '-k', label='numerical')          # doctest: +SKIP
+    >>> plt.loglog(k, res, ':r', label='analytical')        # doctest: +SKIP
+    >>> plt.legend()                                        # doctest: +SKIP
     >>> plt.show()
 
     '''
@@ -220,12 +221,13 @@ class SphericalHankelTransform:
     >>> res = u*(v + w)
     >>>
     >>> import matplotlib.pyplot as plt
-    >>> plt.plot(k, ak, '-k', label='numerical')
-    >>> plt.plot(k, res, ':r', label='analytical')
-    >>> plt.xscale('log')
-    >>> plt.yscale('symlog', linthresh=1e0, subs=[2, 3, 4, 5, 6, 7, 8, 9])
-    >>> plt.ylim(-1e0, 1e3)
-    >>> plt.legend()
+    >>> plt.plot(k, ak, '-k', label='numerical')            # doctest: +SKIP
+    >>> plt.plot(k, res, ':r', label='analytical')          # doctest: +SKIP
+    >>> plt.xscale('log')                                   # doctest: +SKIP
+    >>> plt.yscale('symlog', linthresh=1e0,
+    ...            subs=[2, 3, 4, 5, 6, 7, 8, 9])           # doctest: +SKIP
+    >>> plt.ylim(-1e0, 1e3)                                 # doctest: +SKIP
+    >>> plt.legend()                                        # doctest: +SKIP
     >>> plt.show()
 
     '''
@@ -235,7 +237,7 @@ class SphericalHankelTransform:
     def __call__(self, x):
         return 2**(x-1)*SRPI*cpoch((2+self.mu-x)/2, (2*x-1)/2)
 
-    @fftl.wrap
+    @transform(fftl)
     def fftl(self, r, ar, **kwargs):
         return fftl(self, r, ar*r**2, **kwargs)
 
@@ -283,9 +285,9 @@ class StieltjesTransform:
     >>> res = (2*(s-k) + (k+s)*np.log(k/s))/(k-s)**3
     >>>
     >>> import matplotlib.pyplot as plt
-    >>> plt.loglog(k, ak, '-k', label='numerical')
-    >>> plt.loglog(k, res, ':r', label='analytical')
-    >>> plt.legend()
+    >>> plt.loglog(k, ak, '-k', label='numerical')          # doctest: +SKIP
+    >>> plt.loglog(k, res, ':r', label='analytical')        # doctest: +SKIP
+    >>> plt.legend()                                        # doctest: +SKIP
     >>> plt.show()
 
     Compute the derivative in two ways and compare with numerical and
@@ -306,11 +308,11 @@ class StieltjesTransform:
     >>> aakp = -((-5*k**2+4*k*s+s**2+2*k*(k+2*s)*np.log(k/s))/(k-s)**4)
     >>>
     >>> # show
-    >>> plt.loglog(k, -akp, '-k', label='deriv')
-    >>> plt.loglog(k_, -takp, '-.b', label='rho+1')
-    >>> plt.loglog(k, -nakp, ':g', label='numerical')
-    >>> plt.loglog(k, -aakp, ':r', label='analytical')
-    >>> plt.legend()
+    >>> plt.loglog(k, -akp, '-k', label='deriv')            # doctest: +SKIP
+    >>> plt.loglog(k_, -takp, '-.b', label='rho+1')         # doctest: +SKIP
+    >>> plt.loglog(k, -nakp, ':g', label='numerical')       # doctest: +SKIP
+    >>> plt.loglog(k, -aakp, ':r', label='analytical')      # doctest: +SKIP
+    >>> plt.legend()                                        # doctest: +SKIP
     >>> plt.show()
 
     '''
@@ -320,7 +322,7 @@ class StieltjesTransform:
     def __call__(self, x):
         return cbeta(1+x, -1-x+self.rho)
 
-    @fftl.wrap
+    @transform(fftl)
     def fftl(self, r, ar, *, kr, **kwargs):
         kr = r[-1]*r[0]/kr
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 scipy = ["scipy"]
+test = ["pytest", "matplotlib", "scipy"]
 docs = ["sphinx", "furo", "numpydoc", "scipy", "matplotlib"]
 
 [project.urls]
@@ -28,3 +29,10 @@ Issues = "https://github.com/ntessore/fftl/issues"
 
 [tool.flit.sdist]
 exclude = [".*", "docs"]
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "--doctest-modules"
+testpaths = [
+    "fftl",
+]


### PR DESCRIPTION
Replace the `@fftl.wrap` decorator with a more general `@transform` decorator which can be used for any transform, even already wrapped variants of `fftl()`.