### PR TITLE
document reusable transforms

### DIFF
--- a/docs/build.rst
+++ b/docs/build.rst
@@ -1,0 +1,9 @@
+Reusable transforms
+===================
+
+The generalised FFTLog transforms depend on the coefficient function *u*, on
+the logarithmic grid of input value, and on the parameters *q* and *kr*, but
+not on the data to be transformed.  It is therefore possible to pre-compute a
+reusable transform that can be applied repeatedly to different input data.
+
+.. autofunction:: fftl.build

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@
 
    fftl.rst
    transforms.rst
+   build.rst
 
 
 The *FFTL* package for Python contains a routine to calculate integral

--- a/fftl/__init__.py
+++ b/fftl/__init__.py
@@ -11,6 +11,7 @@ __all__ = [
     "LaplaceTransform",
     "SphericalHankelTransform",
     "StieltjesTransform",
+    "build",
     "transform",
 ]
 
@@ -130,7 +131,33 @@ class _Transform:
 
 def build(u, r, *, q=0.0, kr=1.0, low_ringing=True):
     """
-    Build a transform.
+    Pre-compute a transform that can be applied to data.
+
+    Returns a callable transform with signature ``(ar, *, deriv=False)``.  The
+    logarithmic grid of the transform is available as the attribute *k*.  See
+    :func:`fftl.transform` for a description of the parameters.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+    >>> from scipy.special import gamma
+    >>> import fftl
+    >>>
+    >>> def u_laplace(x):
+    ...     # requires Re(x) = q > -1
+    ...     return gamma(1 + x)
+    ...
+    >>> r = np.logspace(-4, 4, 100)
+    >>>
+    >>> t = fftl.build(u_laplace, r, q=0.5)
+    >>>
+    >>> plt.loglog(t.k, t(np.tanh(r)))                      # doctest: +SKIP
+    >>> plt.loglog(t.k, t(np.sqrt(r)))                      # doctest: +SKIP
+    >>> plt.xlabel('$k$')                                   # doctest: +SKIP
+    >>> plt.ylabel('$T[f](k)$')                             # doctest: +SKIP
+    >>> plt.show()
+
     """
 
     # get the Array API namespace


### PR DESCRIPTION
Add documentation of the low-level `fftl.build()` function for reusable transforms.